### PR TITLE
Remove deprecated option from db url.

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -66,7 +66,7 @@ Create the PostgreSQL database URL
 */}}
 {{- define "ghostfolio.databaseUrl" -}}
 {{- $fullname := (include "ghostfolio.fullname" .) -}}
-{{ printf "postgresql://%s:%s@%s-postgresql.%s.svc:5432/%s?connect_timeout=300&sslmode=prefer" .Values.postgresql.auth.username .Values.postgresql.auth.password $fullname .Release.Namespace .Values.postgresql.auth.database }}
+{{ printf "postgresql://%s:%s@%s-postgresql.%s.svc:5432/%s?connect_timeout=300" .Values.postgresql.auth.username .Values.postgresql.auth.password $fullname .Release.Namespace .Values.postgresql.auth.database }}
 {{- end }}
 
 


### PR DESCRIPTION
The sslmode=prefer parameter in DATABASE_URL is no longer supported in Ghostfolio 3.0.0.