### PR TITLE
Enhanced secret management and extra manifests support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,10 @@ The charts are built and then published to these project _GitHub Pages_, allowin
 - [Ghostfolio Helm Chart](#ghostfolio-helm-chart)
   - [1.1. Prerequisite](#11-prerequisite)
   - [1.2. Configure the application](#12-configure-the-application)
-    - [1.2.1. Use an external PostgreSQL server](#121-use-an-external-postgresql-server)
-    - [1.2.2. Use an external Redis server](#122-use-an-external-redis-server)
+    - [1.2.1. Secret management](#121-secret-management)
+    - [1.2.2. Use an external PostgreSQL server](#122-use-an-external-postgresql-server)
+    - [1.2.3. Use an external Redis server](#123-use-an-external-redis-server)
+    - [1.2.4. Extra manifests](#124-extra-manifests)
   - [1.3. Install the application](#13-install-the-application)
     - [1.3.1. Add the GitHub Helm repository (optional)](#131-add-the-github-helm-repository-optional)
     - [1.3.2. Install the chart](#132-install-the-chart)
@@ -52,8 +54,10 @@ Like any other _Helm_ chart, the available configuration options can be found in
 
     ```yaml
     ghostfolio:
-      ACCESS_TOKEN_SALT: mysuperrandomstring
-      JWT_SECRET_KEY: mysuperrandomstring
+      # ACCESS_TOKEN_SALT and JWT_SECRET_KEY are auto-generated if left empty.
+      # See section 1.2.1 for more options.
+      ACCESS_TOKEN_SALT: ""
+      JWT_SECRET_KEY: ""
 
     # For more information checkout: https://artifacthub.io/packages/helm/bitnami/postgresql
     postgresql:
@@ -87,7 +91,39 @@ Like any other _Helm_ chart, the available configuration options can be found in
               pathType: ImplementationSpecific
     ```
 
-### 1.2.1. Use an external PostgreSQL server
+### 1.2.1. Secret management
+
+By default, `ACCESS_TOKEN_SALT` and `JWT_SECRET_KEY` are **automatically generated** (64-character random strings) on first install. They are preserved across upgrades — if the values are left empty and a secret already exists in the cluster, the existing values are reused.
+
+You have three options:
+
+1. **Auto-generated (default)**: leave `ACCESS_TOKEN_SALT` and `JWT_SECRET_KEY` empty.
+
+    ```yaml
+    ghostfolio:
+      ACCESS_TOKEN_SALT: ""
+      JWT_SECRET_KEY: ""
+    ```
+
+2. **Explicit values**: provide your own strings.
+
+    ```yaml
+    ghostfolio:
+      ACCESS_TOKEN_SALT: mysuperrandomstring
+      JWT_SECRET_KEY: mysuperrandomstring
+    ```
+
+3. **Existing secret**: reference a pre-existing Kubernetes Secret (e.g. managed by ExternalSecrets, SealedSecrets, or Vault). When set, the chart does **not** create its own Secret resource. The existing secret must contain at least `ACCESS_TOKEN_SALT` and `JWT_SECRET_KEY` keys, plus all other keys the deployment expects (e.g. `REDIS_HOST`, `POSTGRES_HOST`, etc.).
+
+    ```yaml
+    ghostfolio:
+      existingSecret: my-ghostfolio-secret
+      # Override key names if your secret uses different keys:
+      # existingSecretAccessTokenSaltKey: ACCESS_TOKEN_SALT
+      # existingSecretJwtSecretKeyKey: JWT_SECRET_KEY
+    ```
+
+### 1.2.2. Use an external PostgreSQL server
 
 By default, the chart deploys a _PostgreSQL_ server via a subchart dependency. However, if want to use your own instance, you can set the following values:
 
@@ -108,7 +144,7 @@ externalPostgresql:
   options: connect_timeout=300&sslmode=prefer
 ```
 
-### 1.2.2. Use an external Redis server
+### 1.2.3. Use an external Redis server
 
 By default, the chart deploys a _Redis_ server via a subchart dependency. However, if want to use your own instance, you can set the following values:
 
@@ -124,6 +160,45 @@ externalRedis:
     secretRef:
       name: "" # When defined, override the .redis.auth.password key
       passwordKey: "password"
+```
+
+<p align="right"><a href="#ghostfolio-helm-chart">back to top</a></p>
+
+### 1.2.4. Extra manifests
+
+You can deploy additional Kubernetes resources alongside the chart by using the `extraManifests` value. Each entry is a raw Kubernetes manifest that is templated through Helm:
+
+```yaml
+extraManifests:
+  - apiVersion: external-secrets.io/v1beta1
+    kind: ExternalSecret
+    metadata:
+      name: ghostfolio-secrets
+    spec:
+      refreshInterval: 1h
+      secretStoreRef:
+        name: vault
+        kind: SecretStore
+      target:
+        name: ghostfolio-secrets
+      data:
+        - secretKey: ACCESS_TOKEN_SALT
+          remoteRef:
+            key: ghostfolio
+            property: access_token_salt
+        - secretKey: JWT_SECRET_KEY
+          remoteRef:
+            key: ghostfolio
+            property: jwt_secret_key
+```
+
+When using `extraManifests` to create a secret that holds `ACCESS_TOKEN_SALT` and `JWT_SECRET_KEY`, combine it with the `existingSecret` option:
+
+```yaml
+ghostfolio:
+  existingSecret: ghostfolio-secrets
+  existingSecretAccessTokenSaltKey: ACCESS_TOKEN_SALT
+  existingSecretJwtSecretKeyKey: JWT_SECRET_KEY
 ```
 
 <p align="right"><a href="#ghostfolio-helm-chart">back to top</a></p>

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -39,10 +39,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.0
+version: 0.5.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "3.0.1"
+appVersion: "3.5.0"

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -68,3 +68,14 @@ Create the Redis database URL
 {{- $fullname := (include "ghostfolio.fullname" .) -}}
 {{ printf "%s-redis-master.%s.svc" $fullname .Release.Namespace }}
 {{- end }}
+
+{{/*
+Return the secret name for Ghostfolio configuration.
+*/}}
+{{- define "ghostfolio.secretName" -}}
+{{- if .Values.ghostfolio.existingSecret -}}
+{{- .Values.ghostfolio.existingSecret -}}
+{{- else -}}
+{{- include "ghostfolio.fullname" . -}}
+{{- end -}}
+{{- end -}}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -43,10 +43,22 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           envFrom:
             - secretRef:
-                name: {{ include "ghostfolio.fullname" . }}
+                name: {{ include "ghostfolio.secretName" . }}
           env:
             - name: DATABASE_URL
               value: "postgresql://$(POSTGRES_USER):$(POSTGRES_PASSWORD)@$(POSTGRES_HOST):$(POSTGRES_PORT)/$(POSTGRES_DB)?$(POSTGRES_OPTIONS)"
+            {{- if .Values.ghostfolio.existingSecret }}
+            - name: ACCESS_TOKEN_SALT
+              valueFrom:
+                secretKeyRef:
+                  key: {{ .Values.ghostfolio.existingSecretAccessTokenSaltKey }}
+                  name: {{ .Values.ghostfolio.existingSecret }}
+            - name: JWT_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: {{ .Values.ghostfolio.existingSecretJwtSecretKeyKey }}
+                  name: {{ .Values.ghostfolio.existingSecret }}
+            {{- end }}
             {{- if and .Values.redis.enabled .Values.redis.auth.enabled .Values.redis.auth.secretRef.name }}
             - name: "REDIS_PASSWORD"
               valueFrom:

--- a/chart/templates/extra-manifests.yaml
+++ b/chart/templates/extra-manifests.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraManifests }}
+---
+{{ tpl (toYaml .) $ }}
+{{- end }}

--- a/chart/templates/secrets.yaml
+++ b/chart/templates/secrets.yaml
@@ -1,5 +1,20 @@
-{{- $tokenSalt := .Values.ghostfolio.ACCESS_TOKEN_SALT | required ".Values.ghostfolio.ACCESS_TOKEN_SALT is required." -}}
-{{- $secretKey := .Values.ghostfolio.JWT_SECRET_KEY | required ".Values.ghostfolio.JWT_SECRET_KEY is required." -}}
+{{- if not .Values.ghostfolio.existingSecret -}}
+{{- $secretName := include "ghostfolio.fullname" . -}}
+{{- $existingSecret := (lookup "v1" "Secret" .Release.Namespace $secretName) -}}
+{{- $accessTokenSalt := .Values.ghostfolio.ACCESS_TOKEN_SALT -}}
+{{- if and (not $accessTokenSalt) $existingSecret -}}
+{{- $accessTokenSalt = index $existingSecret.data "ACCESS_TOKEN_SALT" | b64dec -}}
+{{- end -}}
+{{- if not $accessTokenSalt -}}
+{{- $accessTokenSalt = randAlphaNum 64 -}}
+{{- end -}}
+{{- $jwtSecretKey := .Values.ghostfolio.JWT_SECRET_KEY -}}
+{{- if and (not $jwtSecretKey) $existingSecret -}}
+{{- $jwtSecretKey = index $existingSecret.data "JWT_SECRET_KEY" | b64dec -}}
+{{- end -}}
+{{- if not $jwtSecretKey -}}
+{{- $jwtSecretKey = randAlphaNum 64 -}}
+{{- end -}}
 {{- $fullname := (include "ghostfolio.fullname" .) -}}
 
 apiVersion: v1
@@ -22,7 +37,7 @@ stringData:
   REDIS_HOST: {{ .Values.externalRedis.host | quote }}
   REDIS_PORT: {{ .Values.externalRedis.port | quote }}
   {{- if not .Values.externalRedis.auth.secretRef.name }}
-  REDIS_PASSWORD: {{ .Values.externalRedis.password | quote }}
+  REDIS_PASSWORD: {{ .Values.externalRedis.auth.password | quote }}
   {{- end }}
   {{- end }}
   # DATABASE
@@ -46,10 +61,11 @@ stringData:
   POSTGRES_OPTIONS: {{ .Values.externalPostgresql.options | quote }}
   {{- end }}
   # VARIOUS
-  ACCESS_TOKEN_SALT: {{ $tokenSalt | quote }}
-  JWT_SECRET_KEY: {{ $secretKey | quote }}
+  ACCESS_TOKEN_SALT: {{ $accessTokenSalt | quote }}
+  JWT_SECRET_KEY: {{ $jwtSecretKey | quote }}
   BASE_CURRENCY: {{ .Values.ghostfolio.BASE_CURRENCY | quote }}
   API_KEY_COINGECKO_DEMO: {{ .Values.ghostfolio.API_KEY_COINGECKO_DEMO | quote }}
   API_KEY_COINGECKO_PRO: {{ .Values.ghostfolio.API_KEY_COINGECKO_PRO | quote }}
   HOST: {{ .Values.ghostfolio.HOST | quote }}
   PORT: {{ .Values.ghostfolio.PORT | quote }}
+{{- end -}}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -28,6 +28,9 @@ ghostfolio:
   # ENABLE_FEATURE_AUTH_TOKEN: true
   # REQUEST_TIMEOUT: 2000
   # LOG_LEVELS: ["debug","error","log","warn"]
+  existingSecret: ""
+  existingSecretAccessTokenSaltKey: "ACCESS_TOKEN_SALT"
+  existingSecretJwtSecretKeyKey: "JWT_SECRET_KEY"
 
 # This define the PostgreSQL server configuration that will be deployed using Helm subchart.
 # Set the .enabled key to false to use an external PostgreSQL server.
@@ -203,3 +206,21 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+extraManifests: []
+# - apiVersion: external-secrets.io/v1beta1
+#   kind: ExternalSecret
+#   metadata:
+#     name: ghostfolio-secrets
+#   spec:
+#     refreshInterval: 1h
+#     secretStoreRef:
+#       name: vault
+#       kind: SecretStore
+#     target:
+#       name: ghostfolio-secrets
+#     data:
+#       - secretKey: ACCESS_TOKEN_SALT
+#         remoteRef:
+#           key: ghostfolio
+#           property: access_token_salt


### PR DESCRIPTION
## Summary

This PR adds three enhancements to the Ghostfolio Helm chart:

### 1. Extra manifests support

New `extraManifests` value allows deploying arbitrary Kubernetes resources alongside the chart. Each entry is rendered through Helm templating, enabling use cases like ExternalSecrets, SealedSecrets, or any other K8s manifest.

### 2. Auto-generated secrets

`ACCESS_TOKEN_SALT` and `JWT_SECRET_KEY` are no longer required to be provided as plain text. When left empty, 64-character random strings are automatically generated on first install. Existing values are preserved across upgrades using `lookup`.

### 3. Existing secret support

New `ghostfolio.existingSecret` option allows referencing a pre-existing Kubernetes Secret instead of creating one. Configurable key names via `existingSecretAccessTokenSaltKey` and `existingSecretJwtSecretKeyKey`.

## Changes

- **Chart version** bumped `0.4.0` → `0.5.0`
- **`chart/templates/extra-manifests.yaml`** — new template rendering extra manifests
- **`chart/templates/secrets.yaml`** — auto-generate secrets when empty, skip creation when `existingSecret` is set
- **`chart/templates/deployment.yaml`** — use secret name helper, inject keys from existing secret via `secretKeyRef`
- **`chart/templates/_helpers.tpl`** — new `ghostfolio.secretName` helper
- **`chart/values.yaml`** — added `extraManifests`, `ghostfolio.existingSecret`, `existingSecretAccessTokenSaltKey`, `existingSecretJwtSecretKeyKey`
- **`README.md`** — documented new features (sections 1.2.1 and 1.2.4), renumbered existing sections

## Example usage

### Extra manifests with ExternalSecret

```yaml
extraManifests:
  - apiVersion: external-secrets.io/v1beta1
    kind: ExternalSecret
    metadata:
      name: ghostfolio-secrets
    spec:
      refreshInterval: 1h
      secretStoreRef:
        name: vault
        kind: SecretStore
      target:
        name: ghostfolio-secrets
      data:
        - secretKey: ACCESS_TOKEN_SALT
          remoteRef:
            key: ghostfolio
            property: access_token_salt
        - secretKey: JWT_SECRET_KEY
          remoteRef:
            key: ghostfolio
            property: jwt_secret_key

ghostfolio:
  existingSecret: ghostfolio-secrets
```