### PR TITLE
Move POSTGRES_USER assignment in secrets.yaml

### DIFF
--- a/chart/templates/secrets.yaml
+++ b/chart/templates/secrets.yaml
@@ -53,9 +53,9 @@ stringData:
   POSTGRES_OPTIONS: sslmode=disable&connect_timeout=300
   {{- else }}
   {{- if not .Values.externalPostgresql.auth.existingSecret }}
-  POSTGRES_USER: {{ .Values.externalPostgresql.auth.username | quote }}
   POSTGRES_PASSWORD: {{ .Values.externalPostgresql.auth.password | quote }}
   {{- end }}
+  POSTGRES_USER: {{ .Values.externalPostgresql.auth.username | quote }}
   POSTGRES_DB: {{ .Values.externalPostgresql.auth.database | quote }}
   POSTGRES_HOST: {{ .Values.externalPostgresql.host | quote }}
   POSTGRES_PORT: {{ .Values.externalPostgresql.port | quote }}


### PR DESCRIPTION
Make sure POSTGRES_USER is added in the secret when using external postgresql with existing secret.